### PR TITLE
Bump Microsoft.AspNetCore.OpenApi from 9.0.7 to 9.0.8

### DIFF
--- a/SaturdayQuizWeb/SaturdayQuizWeb.csproj
+++ b/SaturdayQuizWeb/SaturdayQuizWeb.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2025.2.0" />
         <PackageReference Include="Mainwave.MimeTypes" Version="1.6.1" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
         <PackageReference Include="RegexToolbox" Version="2.2.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
     </ItemGroup>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.OpenApi dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch ...